### PR TITLE
Improved the composer metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
-	"name": "iamcal/lib_autolink"
+	"name": "iamcal/lib_autolink",
+	"description": "Adds anchors to urls in a text",
+	"keywords": ["link", "autolink", "anchor"],
+	"autoload": {
+		"files": ["lib_autolink.php"]
+	}
 }
 


### PR DESCRIPTION
The keywords and the description will improve its referencing on Packagist
and the autoload section allows to use the package without bothering about
the location of the file.

Another important missing key in your composer.json is the `license` one. But I was not able to add it as I haven't found any licensing information in your repository. Could you add it ?
