### PR TITLE
Fix XSS vulnerability in title attribute

### DIFF
--- a/lib_autolink.php
+++ b/lib_autolink.php
@@ -156,6 +156,9 @@
 					# add the url
 					#
 
+					$link_url_enc = HtmlSpecialChars($link_url);
+					$display_url_enc = HtmlSpecialChars($display_url);
+
 					$currentTagfill = $tagfill;
 					if ($display_url != $link_url && !preg_match('@title=@msi',$currentTagfill) && $auto_title) {
 
@@ -163,12 +166,9 @@
 
 						if (!preg_match("!^(http|https)://{$display_quoted}$!i", $link_url)){
 
-							$currentTagfill .= ' title="'.$link_url.'"';
+							$currentTagfill .= ' title="'.$link_url_enc.'"';
 						}
 					}
-
-					$link_url_enc = HtmlSpecialChars($link_url);
-					$display_url_enc = HtmlSpecialChars($display_url);
 
 					$buffer .= "<a href=\"{$link_url_enc}\"$currentTagfill>{$display_url_enc}</a>";
 


### PR DESCRIPTION
There's a cross-site scripting vulnerability in the title attribute, since we're already sanitizing `$link_url` for the href attribute we can also do it for the title attribute as well